### PR TITLE
MongoDB: адрес подключения через переменную окружения вместо хардкода

### DIFF
--- a/lib/database/internal.py
+++ b/lib/database/internal.py
@@ -3,6 +3,7 @@ import motor.motor_asyncio
 from bson.codec_options import CodecOptions
 
 from lib.logger.logger import get_logger
+from lib.settings.settings import EnvConfig
 from lib.utils.singleton_factory import singleton
 
 _log = get_logger(__file__, 'InternalDBLogger', 'logs/internal_db.log')
@@ -11,7 +12,7 @@ _log = get_logger(__file__, 'InternalDBLogger', 'logs/internal_db.log')
 @singleton
 class InternalDB():
     def __init__(self) -> None:
-        self.client = motor.motor_asyncio.AsyncIOMotorClient("mongodb://localhost:27017")
+        self.client = motor.motor_asyncio.AsyncIOMotorClient(EnvConfig.MONGODB_URI)
         self.db = self.client.get_database('InternalDB')
         self.collection = self.db.get_collection('internal', codec_options=CodecOptions(tz_aware=True, tzinfo=pytz.utc))
         

--- a/lib/database/players.py
+++ b/lib/database/players.py
@@ -25,7 +25,7 @@ from lib.data_classes.db_player import (
 from lib.data_classes.db_player_old import DBPlayerOld
 from lib.exceptions import database
 from lib.logger.logger import get_logger
-from lib.settings.settings import Config
+from lib.settings.settings import Config, EnvConfig
 from lib.utils.calculate_exp import exp_add
 from lib.utils.singleton_factory import singleton
 from lib.utils.validate_badges import validate_badge
@@ -37,7 +37,7 @@ _log = get_logger(__file__, 'PlayersDBLogger', 'logs/players_db.log')
 @singleton
 class PlayersDB:
     def __init__(self) -> None:
-        self.client = motor.motor_asyncio.AsyncIOMotorClient("mongodb://localhost:27017")
+        self.client = motor.motor_asyncio.AsyncIOMotorClient(EnvConfig.MONGODB_URI)
         self.db = self.client['PlayersDB']
         self.collection = self.db.get_collection('players', codec_options=CodecOptions(tz_aware=True, tzinfo=pytz.utc))
     

--- a/lib/database/servers.py
+++ b/lib/database/servers.py
@@ -2,13 +2,14 @@ from discord import ApplicationContext
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from lib.data_classes.db_server import DBServer, ServerSettings
+from lib.settings.settings import EnvConfig
 from lib.utils.singleton_factory import singleton
 
 
 @singleton
 class ServersDB():
     def __init__(self) -> None:
-        self.client = AsyncIOMotorClient('mongodb://localhost:27017')
+        self.client = AsyncIOMotorClient(EnvConfig.MONGODB_URI)
         self.db = self.client.get_database('ServersDB')
         self.collection = self.db.get_collection('servers')
 

--- a/lib/database/tankopedia.py
+++ b/lib/database/tankopedia.py
@@ -2,6 +2,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 
 from lib.data_classes.tankopedia import Tank
 from lib.logger import logger
+from lib.settings.settings import EnvConfig
 from lib.utils.singleton_factory import singleton
 
 _log = logger.get_logger(__file__, 'TankopediaLogger', 'logs/tankopedia.log')
@@ -10,7 +11,7 @@ _log = logger.get_logger(__file__, 'TankopediaLogger', 'logs/tankopedia.log')
 @singleton
 class TankopediaDB:
     def __init__(self) -> None:
-        self.client = AsyncIOMotorClient("mongodb://localhost:27017")
+        self.client = AsyncIOMotorClient(EnvConfig.MONGODB_URI)
         
         self.db = self.client.get_database('TankopediaDB')
         

--- a/lib/database/utils/dump_handler.py
+++ b/lib/database/utils/dump_handler.py
@@ -5,13 +5,14 @@ from shutil import make_archive
 from pymongo import MongoClient
 
 from lib.logger.logger import get_logger
+from lib.settings.settings import EnvConfig
 
 _log = get_logger(__file__, 'DumpHandlerLogger', 'logs/dump_handler.log')
 
 
 class BackUp:
     def __init__(self):
-        self.client = MongoClient('mongodb://localhost:27017/')
+        self.client = MongoClient(EnvConfig.MONGODB_URI)
 
     def _export_to_google_drive(self):
         ...

--- a/lib/settings/.env.example
+++ b/lib/settings/.env.example
@@ -1,0 +1,31 @@
+# Скопируй этот файл в lib/settings/.env (именно в эту папку — так его ищет settings.py)
+# и подставь реальные значения. Сам .env уже в .gitignore (*.env), в репозиторий не попадёт.
+
+# Discord Developer Portal: https://discord.com/developers/applications
+DISCORD_TOKEN=
+DISCORD_TOKEN_DEV=
+
+# Wargaming Developer Room: https://developers.wargaming.net/
+# Два ID нужны для ротации (lib/settings/settings.py гоняет их через itertools.cycle)
+WG_APP_ID_CL0=
+WG_APP_ID_CL1=
+
+# Lesta Developers (RU-регион): https://developers.lesta.ru/
+LT_APP_ID_CL0=
+LT_APP_ID_CL1=
+
+# Discord OAuth2 (для веб-авторизации, см. cogs/auth.py) — Client ID/Secret из того же
+# приложения в Discord Developer Portal, вкладка OAuth2. DEV-версии — под тестовое приложение.
+CLIENT_ID=
+CLIENT_SECRET=
+CLIENT_ID_DEV=
+CLIENT_SECRET_DEV=
+
+# Внутренний ключ для lib/internal_api — придумай сам, любая случайная строка
+INTERNAL_API_KEY=
+
+# MongoDB Atlas connection string. Формат:
+# mongodb+srv://<username>:<password>@<cluster>.mongodb.net/?appName=Cluster0
+# Пароль с спецсимволами (@ : / # и т.д.) нужно URL-кодировать (urllib.parse.quote_plus),
+# иначе строка подключения ломается на этих символах.
+MONGODB_URI=

--- a/lib/settings/settings.py
+++ b/lib/settings/settings.py
@@ -39,6 +39,8 @@ class EnvConfig():
 
     INTERNAL_API_KEY = os.getenv('INTERNAL_API_KEY')
 
+    MONGODB_URI = os.getenv('MONGODB_URI', 'mongodb://localhost:27017')
+
 
 @singleton
 class Config():


### PR DESCRIPTION
## Что меняется

Во всех местах, где создавался Mongo-клиент, адрес был жёстко прописан как `mongodb://localhost:27017`. Это не даёт подключиться к внешней БД (например MongoDB Atlas) без правки кода.

## Изменения

- `lib/settings/settings.py` — в `EnvConfig` добавлена `MONGODB_URI = os.getenv('MONGODB_URI', 'mongodb://localhost:27017')`. По умолчанию поведение не меняется (тот же localhost), если переменная не задана.
- `lib/database/internal.py`, `players.py`, `servers.py`, `tankopedia.py`, `utils/dump_handler.py` — клиенты (`AsyncIOMotorClient` / `MongoClient`) теперь берут адрес из `EnvConfig.MONGODB_URI`.
- Добавлен `lib/settings/.env.example` с полным списком переменных окружения, которые читает `EnvConfig` (Discord/WG/Lesta токены, OAuth, MONGODB_URI и т.д.). Сам `.env` уже в `.gitignore` (`*.env`), в репозиторий не попадает.

## Важно при настройке

Реальный `.env` должен лежать именно в `lib/settings/.env` — `settings.py` резолвит путь через `os.path.dirname(__file__)`, поэтому `.env` в корне репозитория подхвачен не будет.

## Проверено

Импорт всех пяти изменённых модулей прогнан локально с тестовыми значениями в `.env` — подключение резолвится корректно, синтаксических и импорт-ошибок нет. Реального коннекта к продовой БД при этом не открывается (motor/pymongo создают клиент лениво).